### PR TITLE
Fix docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -73,7 +73,7 @@ RUN /bin/bash -ci "cd $HOME/ros/catkin_ws; catkin_make"
 # libfranka
 RUN mkdir -p ~/lib/libfrankainstall/ && \
     cd ~/lib/libfrankainstall/ && \
-    git clone --recursive https://github.com/frankaemika/libfranka && \
+    git clone --branch 0.13.2 --recursive https://github.com/frankaemika/libfranka && \
     cd libfranka && \
     git submodule update && \ 
     mkdir build && \


### PR DESCRIPTION
Currently, the docker can not be built on a fresh install. 
For the vm, v0.13.2 of libfranka was used, which makes the docker buildable again.
Libfranka v0.14+ has some new dependencies.
Closes #3 