### PR TITLE
Adds flexibility to Docker image name via environment variable

### DIFF
--- a/docker/dc_nvidia.yml
+++ b/docker/dc_nvidia.yml
@@ -2,7 +2,7 @@ version: "2.3"
 services:
 
   gazebo:
-    image: arm_gazebo
+    image: ${DOCKER_IMAGE:-arm_gazebo}
     container_name: armgazebo
     runtime: nvidia
     tty: true

--- a/docker/dc_vnc.yml
+++ b/docker/dc_vnc.yml
@@ -13,7 +13,7 @@ services:
       - "3000:80"
 
   gazebo:
-    image: arm_gazebo
+    image: ${DOCKER_IMAGE:-arm_gazebo}
     container_name: armgazebo
     tty: true
     ipc: host

--- a/docker/dc_x11.yml
+++ b/docker/dc_x11.yml
@@ -2,7 +2,7 @@ version: "2.3"
 services:
 
   gazebo:
-    image: arm_gazebo
+    image: ${DOCKER_IMAGE:-arm_gazebo}
     container_name: armgazebo
     tty: true
     ipc: host

--- a/docker/run.bash
+++ b/docker/run.bash
@@ -2,6 +2,12 @@
 
 export ARM_GAZEBO_DIR=`pwd | gawk '{ print gensub(/\/docker/, "", 1) }'`
 
+if docker image inspect arm_gazebo >/dev/null 2>&1; then
+    export DOCKER_IMAGE="arm_gazebo"
+else
+    export DOCKER_IMAGE="iocchi/arm_gazebo"
+fi
+
 DC=dc_x11.yml
 
 if [ "$1" == "nvidia" ]; then


### PR DESCRIPTION
This PR implements a flexible approach to the Docker image name, allowing the project to work with both locally built images and images pulled via `docker pull`. The change leverages an environment variable (`DOCKER_IMAGE`) in `*.yml` files, enabling the image name to be adjusted based on the context.

- **Changes in `*.yml`:**
The Docker image for the `arm_gazebo` service has been configured to use an environment variable `DOCKER_IMAGE` with a default value of `arm_gazebo`. If the environment variable is not specified, the image name will be automatically set to `arm_gazebo`.

- **Changes in `run.bash`:**
The `run.bash` script now checks if the `arm_gazebo` image is available locally. If the image is not found, the `DOCKER_IMAGE` environment variable is set to the image name `iocchi/arm_gazebo`.

Closes #5 
